### PR TITLE
Update download build log flow

### DIFF
--- a/src/api/error.ts
+++ b/src/api/error.ts
@@ -1,0 +1,12 @@
+export enum ErrorName {
+  NotFound = 'NotFound'
+}
+
+export class NotFoundError extends Error {
+  public name: ErrorName;
+
+  constructor(message?: string) {
+    super(message);
+    this.name = ErrorName.NotFound;
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from './error';
 import * as controller from './controller';
 
 export { controller };

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -10,6 +10,12 @@ export async function downloadDeployLog(
   cur: number = 0
 ): Promise<void> {
   const resp = await sendDownloadLogRequest(context, deploymentID, cur);
+  if (resp.status === 416) {
+    if (context.debug) {
+      console.log('Reached the end of the log...');
+    }
+    return;
+  }
   const result: { needReconnect: boolean; nextCur: number } = await new Promise(
     (resolve, reject) => {
       let count = 0;
@@ -72,7 +78,11 @@ export async function sendDownloadLogRequest(
     },
     method: 'POST'
   }).then((response) => {
-    if (response.status !== 200 && response.status !== 206) {
+    if (
+      response.status !== 200 &&
+      response.status !== 206 &&
+      response.status !== 416
+    ) {
       return handleFailureResponse(response);
     }
 

--- a/src/api/log.ts
+++ b/src/api/log.ts
@@ -1,31 +1,81 @@
-import fetch from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 import url from 'url';
-import { CLIContext } from '../types';
+import { CLIContext, LogEntry, logEntryFromJSON } from '../types';
+import { handleFailureResponse } from './skygear';
 
 export async function downloadDeployLog(
   context: CLIContext,
-  cloudCodeID: string
-) {
+  deploymentID: string,
+  onData: (log: LogEntry) => void,
+  cur: number = 0
+): Promise<void> {
+  const resp = await sendDownloadLogRequest(context, deploymentID, cur);
+  const result: { needReconnect: boolean; nextCur: number } = await new Promise(
+    (resolve, reject) => {
+      let count = 0;
+      resp.body
+        .on('data', (data) => {
+          count += data.length;
+          data
+            .toString('utf-8')
+            .split('\r\n')
+            .map((logJSON: string) => {
+              if (logJSON) {
+                const log = logEntryFromJSON(JSON.parse(logJSON));
+                onData(log);
+              }
+            });
+        })
+        .on('error', (err) => {
+          reject(err);
+        })
+        .on('end', () => {
+          const contentLength = resp.headers.get('content-length');
+          const needReconnect = !contentLength;
+          resolve({
+            needReconnect,
+            nextCur: cur + count
+          });
+        });
+    }
+  );
+
+  if (result.needReconnect) {
+    if (context.debug) {
+      console.log('Reconnect...');
+    }
+    return downloadDeployLog(context, deploymentID, onData, result.nextCur);
+  }
+  if (context.debug) {
+    console.log('Done...');
+  }
+}
+
+export async function sendDownloadLogRequest(
+  context: CLIContext,
+  deploymentID: string,
+  cur: number
+): Promise<Response> {
   const endpoint = context.cluster && context.cluster.endpoint;
   if (!endpoint) {
     return Promise.reject(new Error('no endpoint'));
   }
   return fetch(url.resolve(endpoint, `/_controller/log/download`), {
     body: JSON.stringify({
-      cloud_code_id: cloudCodeID,
+      deployment_id: deploymentID,
       type: 'deploy'
     }),
     headers: {
+      Range: `bytes=${cur}-`,
       'X-Skygear-API-Key': (context.cluster && context.cluster.apiKey) || '',
       'X-Skygear-Access-Token': (context.user && context.user.accessToken) || ''
     },
     method: 'POST'
-  }).then((resp) => {
-    if (resp.status !== 200) {
-      resp.text().then((t) => console.log(t));
-      throw new Error(`Fail to download deploy log of ${cloudCodeID}`);
+  }).then((response) => {
+    if (response.status !== 200 && response.status !== 206) {
+      return handleFailureResponse(response);
     }
 
-    return resp;
+    return response;
   });
 }

--- a/src/configUtil.ts
+++ b/src/configUtil.ts
@@ -27,6 +27,8 @@ export function currentCLIContext(argv: Arguments): CLIContext {
   return {
     app: appName,
     cluster: globalConfig.cluster && globalConfig.cluster[currentContextKey],
-    user: globalConfig.user && globalConfig.user[currentContextKey]
+    debug: !!argv.debug,
+    user: globalConfig.user && globalConfig.user[currentContextKey],
+    verbose: !!argv.verbose
   };
 }

--- a/src/types/cliContext.ts
+++ b/src/types/cliContext.ts
@@ -5,12 +5,16 @@ export interface CLIContext {
   cluster: ClusterConfig | null;
   user: User | null;
   app: string | null;
+  debug: boolean;
+  verbose: boolean;
 }
 
 export function createEmptyCLIContext(): CLIContext {
   return {
     app: null,
     cluster: null,
-    user: null
+    debug: false,
+    user: null,
+    verbose: false
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './clusterConfig';
 export * from './deployment';
 export * from './deploymentItemConfig';
 export * from './globalConfig';
+export * from './logEntry';
 export * from './tenantConfig';
 export * from './user';
 export * from './secret';

--- a/src/types/logEntry.ts
+++ b/src/types/logEntry.ts
@@ -1,0 +1,14 @@
+export interface LogEntry {
+  level: string;
+  message: string;
+  timestamp: Date;
+}
+
+// tslint:disable-next-line:no-any
+export function logEntryFromJSON(input: any): LogEntry {
+  return {
+    level: input.level,
+    message: input.message,
+    timestamp: input.timestamp && new Date(input.timestamp)
+  };
+}


### PR DESCRIPTION
- Reconnect with range header when disconnect. Stop if there is
content-length in the respone header (Complete reading the whole log).
- Parse the structured JSON log
- Retry download only if there is 404, server may return 404 if the
deployment is not started yet